### PR TITLE
feat(site): add baidu and google site verification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ Gemfile.lock
 node_modules
 .jekyll-metadata
 assets/live2d
+package-lock.json

--- a/_data/site.yml
+++ b/_data/site.yml
@@ -64,6 +64,11 @@ mathjax: true
 
 google_analytics: ""  # google analytics code
 
+baidu_site_verification: ""
+google_site_verification: ""
+
+baidu_auto_push: false
+
 lang: "zh-CN"  # lang
 
 deploy: "" # if you used coding pages

--- a/_data/site.yml
+++ b/_data/site.yml
@@ -64,10 +64,10 @@ mathjax: true
 
 google_analytics: ""  # google analytics code
 
-baidu_site_verification: ""
-google_site_verification: ""
+baidu_site_verification: ""  # baidu site verification code
+google_site_verification: ""  # google search console verification code
 
-baidu_auto_push: false
+baidu_auto_push: false  # if you used baidu auto push to commit links
 
 lang: "zh-CN"  # lang
 

--- a/_includes/submission/baidu.html
+++ b/_includes/submission/baidu.html
@@ -1,0 +1,14 @@
+<script>
+    (function(){
+        var bp = document.createElement('script');
+        var curProtocol = window.location.protocol.split(':')[0];
+        if (curProtocol === 'https') {
+            bp.src = 'https://zz.bdstatic.com/linksubmit/push.js';        
+        }
+        else {
+            bp.src = 'http://push.zhanzhang.baidu.com/push.js';
+        }
+        var s = document.getElementsByTagName("script")[0];
+        s.parentNode.insertBefore(bp, s);
+    })();
+</script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,9 @@ layout: compress
         {% if site.data.site.google_analytics != "" %}
         {% include analytics/google.html %}
         {% endif %}
+        {% if site.data.site.baidu_auto_push == true %}
+        {% include submission/baidu.html %}
+        {% endif %}
         {% include component/sw.html %}
         {% include component/customCssJS.html %}
         {% include footer/footer.html %}

--- a/docs/zh-cn/theme-configuration.md
+++ b/docs/zh-cn/theme-configuration.md
@@ -71,6 +71,11 @@ mathjax: true
 
 google_analytics: ""  # google analytics code
 
+baidu_site_verification: ""  # baidu site verification code
+google_site_verification: ""  # google search console verification code
+
+baidu_auto_push: false  # if you used baidu auto push to commit links
+
 lang: "zh-CN"  # lang
 
 deploy: "" # if you used coding pages
@@ -217,7 +222,7 @@ google analytics
 
 ### baidu_site_verification
 
- 百度验证码，用于[百度站长平台](http://zhanzhang.baidu.com)新增站点的验证
+百度验证码，用于[百度站长平台](http://zhanzhang.baidu.com)新增站点的验证
 
 ### google_site_verification
 

--- a/docs/zh-cn/theme-configuration.md
+++ b/docs/zh-cn/theme-configuration.md
@@ -215,6 +215,18 @@ prism 插件
 
 google analytics 
 
+### baidu_site_verification
+
+ 百度验证码，用于[百度站长平台](http://zhanzhang.baidu.com)新增站点的验证
+
+### google_site_verification
+
+谷歌验证码，用于Google Search Console新增站点的验证，Google Search Console和Google Analytics配合起来使用更佳
+
+### baidu_auto_push
+
+是否开启百度链接提交自动推送方式，true为开启，false为关闭，开启后在页面被访问时，页面URL将立即被推送给百度，当然你也可以在[百度站长平台](http://zhanzhang.baidu.com)采用主动推送、sitemap推送或手动提交方式
+
 ### lang
 
 站点语言


### PR DESCRIPTION
我很喜欢该主题，并且我的博客（https://metaphors.name/ ）也用了该主题。我有使用百度站点平台和Google Search Console来管理我的博客。所以如下⬇️⬇️⬇️
新增百度验证码，字段：baidu_site_verification，用于百度站长平台（http://zhanzhang.baidu.com ）新增站点的验证；新增百度链接提交自动推送，字段：baidu_auto_push，详见（http:
//zhanzhang.baidu.com/college/courseinfo?id=267&page=2#h2_article_title1
9 ）；新增谷歌验证码，字段：google_site_verification，用于Google Search Console新增站点的验证。