### PR TITLE
feature: add love page and post description

### DIFF
--- a/_data/love.yml
+++ b/_data/love.yml
@@ -1,0 +1,11 @@
+header:
+    name: "Kejun"
+    favicon: "https://ooo.0o0.ooo/2017/06/08/5939484dc618e.png"
+    siteurl: "https://blog.kejun.space"
+    introduction: "如果真爱有颜色"
+    
+photo:
+    photo: true
+    pictureo: "https://i.loli.net/2018/07/31/5b607051aef7d.jpg"
+    picturet: "https://i.loli.net/2018/07/31/5b607052ce870.jpg"
+    pictureth: "https://i.loli.net/2018/07/31/5b60705508637.jpg"

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -7,6 +7,10 @@
 - name: TAGS
   url: /tags/
   icon: "&#xe893;"
+- name: LOVER
+  url: /love/
+  icon: "&#xe87d;"
+  color: "red"
 - name: FRIENDS
   url: /friends/
   icon: "&#xe8a3;"

--- a/_includes/comment/gitment.html
+++ b/_includes/comment/gitment.html
@@ -4,7 +4,7 @@
 <script>
     setTimeout(function () {
         var gitment = new Gitment({
-            id: '',
+            id: '{{ page.title }}',
             owner: '{{site.data.site.comment.owner}}',
             repo: '{{site.data.site.comment.repo}}',
             oauth: {

--- a/_includes/content/category_post_list.html
+++ b/_includes/content/category_post_list.html
@@ -61,9 +61,15 @@
         </div>
       </div>
       {% endif %}
+	  {% if post.describe != null %}
+      <div class="mdui-card-content mdui-text-color-black-secondary mdui-typo">
+        {{ post.describe}} <a href="{{post.url | prepend: site.baseurl}}">{{lang.post.continue}}</a>
+      </div>
+      {% else %}
       <div class="mdui-card-content mdui-text-color-black-secondary mdui-typo">
         {{ post.excerpt | strip_html}} <a href="{{post.url | prepend: site.baseurl}}">{{lang.post.continue}}</a>
       </div>
+	  {% endif %}
       <div class="mdui-divider"></div>
       <div class="mdui-card-header">
         <div class="mdui-card-menu mdui-typo">

--- a/_includes/content/love.html
+++ b/_includes/content/love.html
@@ -1,0 +1,133 @@
+<style>
+.avatar {
+	width: 100px;
+	height: 100px;
+	padding-left: 16px;
+	padding-right: 16px;
+	padding-top: 24px!important;
+}
+
+.name {
+	color: black!important;
+	font-size: 40px!important;
+	font-weight: bold;
+}
+
+.title {
+	padding-left: 16px!important;
+	padding-top: 12px!important;
+	size: 12px!important;
+}
+
+a:link {
+	text-decoration: none;
+}
+
+a:visited {
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: none;
+}
+
+a:active {
+	text-decoration: none;
+}
+
+.primary-title {
+	color: black!important;
+}
+
+.padding-bottom-8px {
+	padding-bottom: 8px!important;
+}
+
+.padding-bottom-16px {
+	padding-bottom: 16px!important;
+}
+
+.k-post-media {
+	display: block cursor: pointer;
+	max-height: 250px;
+	min-height: 250px;
+	height: 250px;
+	background-position: 50% 50%;
+	background-size: cover;
+	background-color: #303033;
+}
+</style>
+<body>
+    <div class="padding">
+        <div class="mdui-container">
+            <div class="mdui-col-md-1 mdui-col-sm-1">
+            </div>
+            <div class="mdui-col-md-10 mdui-col-sm-10">
+                <div class="animated flipInX mdui-card mdui-shadow-{{site.data.site.card.card_shadow}} {% if site.data.site.card.card_hoverable == true%}mdui-hoverable{% endif %}">
+                    <div class="mdui-card-primary-title title">
+                        我的情侣
+                    </div>
+                    <div class="mdui-typo">
+                        <hr/>
+                    </div>
+                    <a href="{{site.data.love.header.siteurl}}" target="_blank">
+                        <img class="avatar mdui-center" src="{{site.data.love.header.favicon}}"/>
+					</a>
+                        <div class="mdui-card-primary">
+                            <h1 class="padding-bottom-8px mdui-card-primary-title name mdui-text-center">
+                    <a href="{{site.data.love.header.siteurl}}" target="_blank">
+					<font color="black">
+                                {{site.data.love.header.name}}
+					</font>
+					</a>
+                            </h1>
+                            <div class="padding-bottom-8px primary-title mdui-card-primary-subtitle mdui-text-center">
+                    <a href="{{site.data.love.header.siteurl}}" target="_blank">
+					<font color="black">
+                                {{site.data.love.header.introduction}}
+					</font>
+                    </a>
+							</div>
+						</div>
+                </div>
+                </br>
+                </br>
+				{% if site.data.love.photo.photo == true %}
+                <div class=" animated flipInX lazyload mdui-card mdui-shadow-{{site.data.site.card.card_shadow}} {% if site.data.site.card.card_hoverable == true%}mdui-hoverable{% endif %}">
+                    <div class="mdui-card-primary-title title">
+                        相册
+                    </div>
+                    <div class="mdui-typo">
+                        <hr/>
+                    </div>
+                    <div class="mdui-col-md-12 mdui-col-sm-12">
+                        <div class="padding-bottom-16px mdui-col-md-4 mdui-col-sm-6">
+                            <div class="mdui-card mdui-shadow-2">
+                                <div class="mdui-card-media k-post-media lazy" data-original="{{site.data.love.photo.pictureo}}">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="padding-bottom-16px mdui-col-md-4 mdui-col-sm-6">
+                            <div class="mdui-card mdui-shadow-2">
+                                <div class="mdui-card-media k-post-media lazy" data-original="{{site.data.love.photo.picturet}}">
+                                </div>
+                            </div>
+                        </div>
+                        <div class="padding-bottom-16px mdui-col-md-4 mdui-col-sm-6">
+                            <div class="mdui-card mdui-shadow-2">
+                                <div class="mdui-card-media k-post-media lazy" data-original="{{site.data.love.photo.pictureth}}">
+                                </div>
+                            </div>
+                        </div>
+						<div class="padding-bottom-8px">
+						</div>
+                    </div>
+                </div>
+				{% else %}
+				{% endif %}
+            </div>
+        </div>
+	</div>
+
+    {% include content/component/lazyload.html %}
+</body>

--- a/_includes/content/page_content.html
+++ b/_includes/content/page_content.html
@@ -46,6 +46,11 @@
                     <div class="mdui-card-media-covered mdui-card-media-covered-gradient">
                         <div class="mdui-card-primary">
                             <h1 class="mdui-card-primary-title"><a class="mdui-text-color-white-text">{{page.title}}</a></h1>
+                            {% if page.describe != null %}
+                            <div class="mdui-card-primary-subtitle">
+                                {{page.describe}}
+                            </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/_includes/content/page_content_no_toc.html
+++ b/_includes/content/page_content_no_toc.html
@@ -27,6 +27,11 @@
                     <div class="mdui-card-media-covered mdui-card-media-covered-gradient">
                         <div class="mdui-card-primary">
                             <h1 class="mdui-card-primary-title"><a class="mdui-text-color-white-text">{{page.title}}</a></h1>
+                            {% if page.describe != null %}
+                            <div class="mdui-card-primary-subtitle">
+                                {{page.describe}}
+                            </div>
+                            {% endif %}
                         </div>
                     </div>
                 </div>

--- a/_includes/content/paginator_post_list.html
+++ b/_includes/content/paginator_post_list.html
@@ -57,9 +57,15 @@
         </div>
       </div>
       {% endif %}
+      {% if post.describe != null %}
+      <div class="mdui-card-content mdui-text-color-black-secondary mdui-typo">
+        {{post.describe}} <a href="{{post.url | prepend: site.baseurl}}">{{lang.post.continue}}</a>
+      </div>
+      {% else %}
       <div class="mdui-card-content mdui-text-color-black-secondary mdui-typo">
         {{ post.excerpt | strip_html}} <a href="{{post.url | prepend: site.baseurl}}">{{lang.post.continue}}</a>
       </div>
+      {% endif %}
       <div class="mdui-divider"></div>
       <div class="mdui-card-header">
         <div class="mdui-card-menu mdui-typo">

--- a/_layouts/love.html
+++ b/_layouts/love.html
@@ -1,0 +1,4 @@
+---
+layout: default
+---
+{% include content/love.html %}

--- a/_posts/2016-04-14-ubuntu-installs-apache-masql-php-and-phpmyadmin.markdown
+++ b/_posts/2016-04-14-ubuntu-installs-apache-masql-php-and-phpmyadmin.markdown
@@ -6,12 +6,8 @@ categories: technology
 tags: ubuntu apache mysql php phpmyadmin
 img: https://ooo.0o0.ooo/2017/05/27/59292b1243dc9.jpg
 author: test
+describe: 还原了服务器，于是重装，顺路记录下来，路过的朋友们可以借鉴，LAMP Go!
 ---
-
-还原了服务器，于是重装，顺路记录下来，路过的朋友们可以借鉴，LAMP Go!
-
-* 
-{:toc}
 
 ## Apache
 

--- a/_posts/2017-05-27-liquid-template-language.markdown
+++ b/_posts/2017-05-27-liquid-template-language.markdown
@@ -5,9 +5,8 @@ date:   2017-05-27 16:18:06 +0800
 categories: Living
 tags: liquid jekyll
 img: https://ooo.0o0.ooo/2017/05/27/5929360544b21.jpg
+describe: 此博文用于记录研究 jekyll 时遇到的有趣 `liquid` 语言片段。
 ---
-
-此博文用于记录研究 jekyll 时遇到的有趣 `liquid` 语言片段。
 
 ## 统计捐赠
 

--- a/_posts/2018-02-13-goodbey-yy-fuck-yy.markdown
+++ b/_posts/2018-02-13-goodbey-yy-fuck-yy.markdown
@@ -5,9 +5,8 @@ date: 2018-02-13 13:26:16 +0800
 categories: Living
 tags: discord game yy
 img: https://i.loli.net/2018/02/13/5a8299ad7dff9.png
+describe: 为什么要使用流氓 YY ？
 ---
-
-为什么要使用流氓 YY ？
 
 首先，[点击这里](https://discordapp.com/)下载 Discord 。
 

--- a/docs/zh-cn/creating-posts.md
+++ b/docs/zh-cn/creating-posts.md
@@ -16,6 +16,7 @@ date: 2016-04-14 10:24:49 +0800
 categories: technology
 tags: ubuntu apache mysql php phpmyadmin
 img: https://ooo.0o0.ooo/2017/05/27/59292b1243dc9.jpg
+describe: 还原了服务器，于是重装，顺路记录下来，路过的朋友们可以借鉴，LAMP Go!
 ---
 ```
 
@@ -58,11 +59,11 @@ lastupdate: 2017-06-25 12:24:49 +0800
 
 #### categories
 
-文章所属分类
+文章所属分类，可使用空格添加多个分类
 
 #### tags
 
-文章包含的标签，使用空格分开多个标签。
+文章包含的标签，可使用空格分开多个标签
 
 #### img
 
@@ -77,3 +78,7 @@ lastupdate: 2017-06-25 12:24:49 +0800
 #### themetextcolor
 
 移动端的header文本颜色
+
+#### describe
+
+为文章添加一段简介，简介将出现在文章卡片的下方；若不添加，则将默认使用文章开头的第一句话作为简介

--- a/pages/love.html
+++ b/pages/love.html
@@ -1,0 +1,4 @@
+---
+layout: love
+permalink: /love/
+---


### PR DESCRIPTION
## 重新添加love页面

在 @Mysaku 制作的原版上进行了以下修改：
1. 修复图片外链硬编码问题
2. 删除 `_includes/content/love.html` 中无用的 padding，由此改进了使用padding来避免遮挡的不良布局方式
3. 删除 `_includes/content/love.html` 中点击图片时的无用涟漪效果
4. 删除 `_includes/content/love.html` 中不合逻辑的 `mdui-fab-wrapper`

## 重新添加博文 metainfo 中的 descript 项

做了以下修改：
1. 删除 `_data/site.yml` 中无用的开关选项
2. 根据文章头部元信息中的 `descript` 字段自动选择添加描述
3. 当设置了文章头图并使用 `descript` 字段时，使用 `descript` 字段作为副标题
4. 添加了相应功能的文档，并修改了部分样例文档

最后，再次感谢 @Mysaku 编写的love页面